### PR TITLE
PiRC1: Pi Ecosystem Token Design / MapCap

### DIFF
--- a/PiRC1/1-vision.md
+++ b/PiRC1/1-vision.md
@@ -21,3 +21,12 @@ Pi Launchpad aims to provide:
 - **On-chain transparency** of the launch process ensured by immutable smart contracts.
 
 Next: [`2-Core-Design`](2-core-design.md)
+
+---
+## 📍 PiRC1 Feedback – Section 1: Vision
+
+> The LaunchPad and my MapCap use case visions are both similar in most respects, with the following key differences:
+>
+> - **LaunchPad** includes the excellent **Engagement Reward** feature.  
+> - **MapCap** includes an ongoing **“Post-TGE Rewards”** feature, which continues rewarding token owners for utility usage after TGE for the whole lifespan of the app.
+

--- a/PiRC1/2-core-design.md
+++ b/PiRC1/2-core-design.md
@@ -47,3 +47,23 @@ flowchart LR
 ```
 
 Next: [`3-Participation`](3-participation.md)
+
+---
+
+## 📍 PiRC1 Feedback – Section 2: Core Design
+
+The LaunchPad and my MapCap use case core designs are both similar in most respects, with the following key differences:
+
+> - **Re 1. Participation Window** – LaunchPad includes the excellent **Engagement Reward** feature.
+>
+> - **Re 2. Allocation Period: Liquidity Formation & Distribution** – MapCap includes a **“Whale Mitigation”** step between the end of the LaunchPad phase and the TGE event. At that stage:
+>   - Total stake by any single participant is capped at **10%** of the total of all stakes.
+>   - Excess staked Pi from large participants is **refunded immediately** after the LaunchPad price discovery period.
+>   - Token allocations correspond to the adjusted stake amounts.
+>
+> - **Re 4. Post-launch Period** – The PiRC1 paper describes:  
+>   *“Projects are required to have clear unlock schedules that are not more favorable than the community.”*  
+>   The MapCap use case is aligned with this approach. The first draft (still in review/amendment) is as follows:
+>   - All participants receive **token allocations proportional** to the Pi they’ve staked (after whale-cap adjustment).
+>   - Allocation reflects the calculated **Engagement Reward** as described in the PiRC1 paper.
+>   - Allocation is **vested over 10 months**, with **10% released at the end of each month** to prevent massive post-launch dumps immediately after LP opening for public trading.

--- a/PiRC1/3-participation.md
+++ b/PiRC1/3-participation.md
@@ -20,3 +20,20 @@ $$
 
 
 Next: **4-Allocation [`Design 1`](<4-allocation/4-allocation design 1.md>) [`Design 2`](<4-allocation/4-allocation design 2.md>)**
+
+---
+
+## 📍 PiRC1 Feedback – Section 3: Participation
+
+The LaunchPad and my MapCap use case participation models are both similar in most respects, with the following key differences:
+
+> - **LaunchPad** includes the excellent **Engagement Reward** feature.
+>
+> - As mentioned at the top of this document, I recommend that the first LaunchPad MVP **prioritize tracking and rewarding engagement via Pi wallet-to-wallet transfer events**. Other event tracking (e.g., app-specific milestones) can be added in later iterations once mitigations for fraudulent replication are identified.
+>
+> - The **MapCap use case** allows any Pioneer with a **mainnet wallet** to participate in the LaunchPad process — it is **not gated** by invitation or selection.
+>
+> - We will offer **app developers a button** they can embed in their app to invoke the MapCap/LaunchPad app, or users can invoke it directly in Pi Browser. Once in the MapCap app:
+>   - Users can view the **MapCap token spot-price trend line** over the duration of the LaunchPad phase.  
+>   - Users can view the **status of total Pi staked** and their own **total stake position**.  
+>   - Users can **add extra Pi** to their stake or **reduce/withdraw** a percentage (partially or entirely) of their stake at any time.

--- a/PiRC1/4-allocation/4-allocation design 1.md
+++ b/PiRC1/4-allocation/4-allocation design 1.md
@@ -152,3 +152,30 @@ xychart-beta
 - Highly engaged participants pay $0.909p_{list}$. Medimum engaged participants pay $0.952p_{list}$. Least engaged participants pay $p_{list}$
 
 Next: [`5-tge-state`](<../5-tge-state/5-tge-state design 1.md>)
+
+---
+
+## 📍 PiRC1 Feedback – Section 4: Design (1 and 2)
+
+Both the LaunchPad and my MapCap use case detailed designs are similar in most respects, with the following key differences:
+
+> - **LaunchPad** offers two designs (**Design 1** and **Design 2**).
+>
+> - **MapCap** currently uses a design like **Design 1**. The use case currently doesn’t consider participants with locked-up Pi or **Design 2**. However, we propose:
+>   - To include the PiRC1 **locked-up Pi approach** in the MVP.
+>   - To explore **Design 2** in later iterations of the service.
+>
+> - **MapCap calculates T(available)** as a proportion of total **T(minted)**, with the remainder as **T(liquidity)**:  
+>   - T(available) → transferred to participants during allocation distribution.  
+>   - T(liquidity) → deposited into the LP just prior to market opening.  
+>   - This ensures the **LP opening spot price (P(list))** for all LaunchPad participants is **10% lower** than the AMM-calculated P(list) at LP opening.  
+>   - Participants feel rewarded as the opening spot price is effectively **10% higher** than the price paid in the LaunchPad phase.  
+>   - Note: Tokens are vested; the first tranche is released at the end of the first month after TGE.
+>
+> - **Engagement Reward Integration:**  
+>   - MapCap will set aside a portion of **T(available)** as **T(engage)**.  
+>   - T(engage) will be distributed based on **utility engagement**, so highly engaged participants receive more MapCap tokens than less engaged participants staking the same amount of Pi.
+>
+> - **Design 1 vs Design 2:**  
+>   - Initial LaunchPad MVP should use **Design 1** (simpler algorithm).  
+>   - **Design 2** can be included in a subsequent iteration based on user demand.

--- a/PiRC1/5-tge-state/5-tge-state design 1.md
+++ b/PiRC1/5-tge-state/5-tge-state design 1.md
@@ -56,3 +56,43 @@ In the base case with no rewards ($T_{engage}=0$), this gives $p_{floor}=0.25\,p
 **Intuitively:** even to the extent of “everyone swaps every token of theirs back to the pool”, the pool cannot be drained because the Escrow Wallet that added the liqludiity initially is locked and cannot withdraw from the pool; the pool still retains nearly half of the entire initial participant commitment ($0.488C$ Pi) and all of the tokens in circulation ($2.05T$ tokens), which mathematically prevents the price to drop further than 23.8% of $p_{list}$ in this construct.
 
 Next: [`Design 2`](<../4-allocation/4-allocation design 2.md>)
+
+---
+
+## 📍 PiRC1 Feedback – Section 5: Official TGE / Market Opening
+
+The TGE and market openings of both LaunchPad and my MapCap use case are similar in most respects, with the following key differences:
+
+> - **MapCap LP / Market Opening:**  
+>   - The LP/market opens for **unrestricted public access immediately after TGE**.  
+>   - Any Pioneer with a **mainnet wallet**, including LaunchPad participants, can buy MapCap tokens at **LP spot-price** and sell them.  
+>   - Tokens purchased during LaunchPad phase can only be **sold after vesting** (10% released at the end of each month after TGE).  
+>   - All tokens sold via MapCap LP, regardless of purchase timing, are **market sales** at the LP spot price at the time of sale.
+>
+> - **Governance Participation:**  
+>   - All token holders can participate in **app governance decisions** (e.g., feature prioritization, dividend amounts/frequency, engagement reward formulae).  
+>   - Governance participation occurs via **surveys, demos/reviews, and voting**.
+>
+> - **Post-TGE Rewards:**  
+>   - Ongoing rewards continue **forever after TGE** until app dissolution.  
+>   - Functionally similar to **dividends**: MapCap token holders receive **Pi payments** directly in their wallets.  
+>   - Frequency and amount of payouts are determined by **app governance**, based on revenue/profitability.  
+>   - Payouts are **proportional to token holdings**, optionally adjusted by **utility engagement value**.
+>
+> - **Engagement Incentive Continuation:**  
+>   - Utility engagement at payout is calculated using the **LaunchPad engagement algorithm**.  
+>   - Higher engagement → higher reward.  
+>   - Dividend engagement algorithm can only be changed via **token-holder-approved governance**.
+>
+> - **No Hard Price Floor (P(floor))**:  
+>   - In MapCap, LP can go as low as **zero Pi** if all tokens are sold back.  
+>   - Developers may intervene **optionally**, via governance, to restore Pi liquidity and token value.  
+>   - This allows **market-driven confidence** while keeping P(floor) flexible.
+>
+> - **End-of-Life / Dissolution Handling:**  
+>   - Token spot price can reduce to zero if the app ceases to exist.  
+>   - To prevent unfairness, MapCap includes an **LP exit process** before dissolution news:  
+>     - LP trading is suspended.  
+>     - A **single exit spot price (P(exit))** is calculated from remaining Pi vs total token holdings.  
+>     - During a **4-week exit period**, all token holders may swap tokens at **P(exit)**, ensuring fairness.  
+>     - After the exit period, remaining tokens can still be redeemed, but are essentially worthless.


### PR DESCRIPTION
### 💡 MapCap Use Case Feedback for PiRC1
+ **Submitted on behalf of:** Philip Jennings aka peejenn | Map of Pi Owner + Product Manager
+ Comment response to “PiRC1: Pi Ecosystem Token Design (Pi Request for Comment)”.
+ See attached document for raw version @ [PiRC1_ Pi Ecosystem Token Design_Map of Pi PM.pdf](https://github.com/user-attachments/files/25955534/PiRC1_.Pi.Ecosystem.Token.Design_Map.of.Pi.PM.pdf)

---

We are so excited to read about the LaunchPad approach in the PiRC1 paper because of its similarity to the MapCap use case we’ve separately independently drafted. Our MapCap use case adopts the same principles of price-discovery fairness and rug-pull restriction as LaunchPad, and goes further by also continuing to reward token holders post-TGE. We’ve paused our MapCap development work because we see that PiRC1 fulfills the needs of the MapCap use case. However we would love to restart that development, and pivot it to PiRC1 development. We offer our inputs to Pi Network on a fully volunteer pro bono basis. We believe that our additional MapCap features would further enhance fairness and facilitate additional meaningful pi utility, and therefore we wonder if they could also be included into PiRC1? We saw that PiRC1 includes the exciting additional principle of "Engagement Reward" during the LaunchPad phase, which we hadn’t considered for the MapCap use case, and we think it’s a fantastic addition. The MapCap use case includes a “Post-TGE Rewards” feature which operates on an ongoing basis throughout the lifespan of the app/LP. The purpose of this is to encourage continued ongoing MapCap token ownership, rather than just LaunchPad participation. We will enhance “Post-TGE Rewards” to also reward continued pi utility engagement, as this drives long term meaningful pi utility throughout the lifespan of the app, rather than just during the LaunchPad phase. The MapCap use case is drafted to enable fast development of an initial minimum viable product (MVP) covering all essential features. This enables us to achieve a working product quickly so we can demo and iterate fast based on feedback, additional edge cases and Pi Core Team aspirations. The context of this comment response includes the following:

1. We recognise that a primary goal of Pi Network is to maximise meaningful pi utility.
2. Our assessment suggests to us that the only meaningful pi utility is wallet-to-wallet transfer of pi. All other app activities are either an enabler to that wallet transfer, or an outcome from it, i.e. they’re not a meaningful utility activity in their own right.
3. Pi Network can already directly and unambiguously observe all wallet-to-wallet transfers (payer, recipient, app that facilitated it, pi amount, timestamp of transfer).
4. Our assessment also indicates that unfortunately there’s a high risk that all other user-app milestones could be fabricated/spoofed by developer algorithms and/or manual activities. Therefore calculating engagement reward on any milestones other than wallet transfer would require extensive and complex protections to be built into the PiRC1 algorithms.

In line with this context we believe that the first implementation of PiRC1 should measure meaningful pi utility only by observing pi wallet-to-wallet transfer activity. This would prove the base engagement reward concept and bring a product into live quickly. Then, later, other engagement interactions (e.g. app login, and other app milestones which are significant to usage of a specific app) could be added in future iterations when the risks and mitigations against fraudulent replication of those milestones are identified.

The Map of Pi team would be delighted to assist Pi Core Team in development of PiRC1 on a volunteer pro bono basis. I will also be happy to share our detailed MapCap use case with Pi Core Team if that’s helpful. In the meantime the image below shows the MapCap app UI, together with associated high level UX use case, which provides user access during the MapCap price discovery phase (i.e. equivalent of the LaunchPad phase). The MapCap UI is designed for a mobile phone screen because the majority of pioneers interact with the pi ecosystem using their mobile device.

<img width="620" height="503" alt="image" src="https://github.com/user-attachments/assets/6764fc52-f502-450f-8b77-9e228d568c0f" />

Our key suggestion is that PiRC1/LaunchPad is built initially as an MVP based on the following headline principles:
● The only meaningful milestone for pi utility engagement reward is wallet-to-wallet transfer.
● Token-holder utility engagement rewards should continue post-TGE for the lifetime of the app/LP.
● Include a fair-for-all token-holder exit mechanism at app/LP end of life.

The Map of Pi team can’t wait to be early adopters of a Pi Network owned PiRC1/LaunchPad for us to use for our MapCap token in Mainnet. We would love to help you build PiRC1 by enabling you to leverage the MapCap work we’ve already performed, and also we offer the Map of Pi developer team on a volunteer pro bono basis to build it for you in line with your design, standards and QA.

All best, Philip.
**#mapofpi**