### PR TITLE
Add PiRC3 Micron Standard specification π—π

### DIFF
--- a/PiRC3/micron_standard.md
+++ b/PiRC3/micron_standard.md
@@ -1,0 +1,45 @@
+      ┌──────────┐         ┌──────────┐
+      │  π - π   │         │  π - π   │
+      └────┬─────┘         └────┬─────┘
+           │   Parallel Lattice │
+      ┌────┴─────┐         ┌────┴─────┐
+      │  π - π   │         │  π - π   │
+      └──────────┘         └──────────┘
+
+#### **1. Abstract & Motivation**
+
+* **The Problem:** Unit bias and high fraction readability in small transactions. Human users struggle to calculate micro-fees (e.g., $0.000005\ \pi$), and autonomous agents/IoT devices (like DIMO telemetry or OpenMind robotics) need a standardized, granular base unit to execute automated micro-tasks without rounding errors.
+
+
+* **The Solution:** Establish **$1\ \mu\pi = 10^{-6}\ \pi$** as the official protocol-level micro-unit for developer SDKs, smart contracts, and M2M payment rails.
+
+
+
+#### **2. Core Technical Specification**
+
+* **Base Denomination:** Formalize the Micron ($\mu\pi$) in the SDK:
+
+
+
+$$1\ \text{Pi} (\pi) = 1,000,000\ \text{Microns} (\mu\pi)$$
+
+
+* **M2M Execution Formula:** Standardize dynamic compute and API pricing for automated services:
+
+
+
+$$\text{Cost} = \sum_{i=1}^{n} (t_i \times \mu\pi_{\text{rate}})$$
+
+
+
+* **Developer Utility:** Standardize how Pi App Studio dApps and Soroban smart contracts parse gas, telemetry logs, and micro-subscriptions using integer-based Microns rather than complex floating-point decimal operations.
+
+
+
+#### **3. Network Stability & Economic Mechanics**
+
+* **Incentivizing Infrastructure:** Address how micro-transaction fee routing can directly reward node operators running continuous Docker environments, creating a self-sustaining feedback loop between active compute nodes and M2M service demand.
+
+
+* **Decoupling from Fiat Volatility:** By anchoring dApp micro-services to fixed $\mu\pi$ rates, services maintain internal utility pricing regardless of external exchange fluctuations.
+


### PR DESCRIPTION
Introduced the Micron ($\mu\pi$) as a standardized micro-unit for transactions, detailing its specifications and implications for developers and network stability.